### PR TITLE
修复云游戏鼠标捕获并调整串流默认参数

### DIFF
--- a/src/Extensions/Waves.Api/Models/CloudGame/WelinkMessage.cs
+++ b/src/Extensions/Waves.Api/Models/CloudGame/WelinkMessage.cs
@@ -69,6 +69,9 @@ namespace Waves.Api.Models.CloudGame
 
         [JsonPropertyName("detail")]
         public NetworkDetail? Detail { get; set; }
+
+        [JsonPropertyName("visible")]
+        public bool Visible { get; set; }
     }
 
 

--- a/src/Waves.Core/Helpers/CloudGameDataHelper.cs
+++ b/src/Waves.Core/Helpers/CloudGameDataHelper.cs
@@ -8,11 +8,6 @@ public static class CloudGameDataHelper
     public const string WelinkTenantKey = "1853717215719854081";
     public const string WelinkGameId = "1853717365355843585600007";
     public const string MainUrl = "https://mc.kurogames.com/cloud/index.html";
-    private const int MinStreamWidth = 640;
-    private const int MinStreamHeight = 360;
-    private const int MaxStreamWidth = 3840;
-    private const int MaxStreamHeight = 2160;
-
     public static void BuildLauncheOption(CloudGameLoginSession login) { }
 
     public static Dictionary<string, string> BuildWebStorageItems(CloudGameLoginSession login)
@@ -206,18 +201,17 @@ public static class CloudGameDataHelper
         bool clampToWindow
     )
     {
-        var dpiScale = quality.DPI / 96.0;
         var isSmooth = quality.Type ==  Models.Enums.CloudQualityType.Smooth;
-        double maxScale = isSmooth ? 2.0 / 3.0 : 1.0;
-        var maxW = (int)Math.Round(quality.Width * maxScale);
-        var maxH = (int)Math.Round(quality.Height * maxScale); 
-        var physicalWidth = (int)Math.Round(quality.Width * dpiScale);
-        var physicalHeight = (int)Math.Round(quality.Height * dpiScale); 
-        physicalWidth = ClampEven(physicalWidth, 640, maxW);
-        physicalHeight = ClampEven(physicalHeight, 360, maxH);
-        const double targetBitratePerPixel = 0.013;
-        var targetBitRate = (int)(physicalWidth * physicalHeight * targetBitratePerPixel);
-        targetBitRate = Math.Clamp(targetBitRate, 5000, 50000);
+        var physicalWidth = isSmooth
+            ? CloudGameMethod.MinStreamWidth
+            : CloudGameMethod.MaxStreamWidth;
+        var physicalHeight = isSmooth
+            ? CloudGameMethod.MinStreamHeight
+            : CloudGameMethod.MaxStreamHeight;
+        var targetBitRate = isSmooth
+            ? (int)(physicalWidth * physicalHeight * 0.013)
+            : CloudGameMethod.ClarityBitRate;
+        targetBitRate = Math.Clamp(targetBitRate, 5000, CloudGameMethod.ClarityBitRate);
         return new StreamQualityOptions(
             targetBitRate,
             quality.BitRateMin,
@@ -314,12 +308,16 @@ public static class CloudGameDataHelper
 
     private static string GetPreferredResolution(int dpi, int maxWidth, int maxHeight)
     {
-        var dpiScale = Math.Max(1.0, dpi / 96.0);
-        var screenWidth = (int)Math.Round(maxWidth * dpiScale);
-        var screenHeight = (int)Math.Round(maxHeight * dpiScale);
-
-        screenWidth = ClampEven(screenWidth, MinStreamWidth, MaxStreamWidth);
-        screenHeight = ClampEven(screenHeight, MinStreamHeight, MaxStreamHeight);
+        var screenWidth = ClampEven(
+            maxWidth,
+            CloudGameMethod.MinStreamWidth,
+            CloudGameMethod.MaxStreamWidth
+        );
+        var screenHeight = ClampEven(
+            maxHeight,
+            CloudGameMethod.MinStreamHeight,
+            CloudGameMethod.MaxStreamHeight
+        );
 
         return $"{screenWidth}x{screenHeight}";
     }

--- a/src/Waves.Core/Services/CloudGameServices/CloudGameMethod.cs
+++ b/src/Waves.Core/Services/CloudGameServices/CloudGameMethod.cs
@@ -24,5 +24,6 @@ public class CloudGameMethod
     public const int MinStreamHeight = 720;
     public const int MaxStreamWidth = 1920;
     public const int MaxStreamHeight = 1080;
+    public const int ClarityBitRate = 25000;
 
 }

--- a/src/WutheringWavesTool/Common/KuroWebView/CloudGameBuilder.cs
+++ b/src/WutheringWavesTool/Common/KuroWebView/CloudGameBuilder.cs
@@ -820,10 +820,15 @@ public static class CloudGameBuilder
             const getPhysicalResolution = () => {
                 const viewport = getViewportResolution();
                 const scale = Number(window.devicePixelRatio) > 0 ? Number(window.devicePixelRatio) : 1;
-                const physical = normalizeResolution(viewport.width * scale, viewport.height * scale);
+                const configuredWidth = Number(payload.bridgeConfig?.targetWidth);
+                const configuredHeight = Number(payload.bridgeConfig?.targetHeight);
+                const physical = configuredWidth > 0 && configuredHeight > 0
+                    ? normalizeResolution(configuredWidth, configuredHeight)
+                    : normalizeResolution(viewport.width * scale, viewport.height * scale);
                 return {
-                    ...viewport,
                     ...physical,
+                    viewportWidth: viewport.width,
+                    viewportHeight: viewport.height,
                     scale
                 };
             };
@@ -1172,40 +1177,6 @@ public static class CloudGameBuilder
                 setTimeout(() => overlay?.remove(), 260);
             };
 
-            // Pointer lock state tracking (matching official kurogames behavior)
-            let isPointerLocked = false;
-            let pointerLockEscTimer = null;
-
-            document.addEventListener("pointerlockchange", () => {
-                clearTimeout(pointerLockEscTimer);
-                const video = document.getElementById("WelinkGameVideo");
-                if (document.pointerLockElement === video) {
-                    isPointerLocked = true;
-                } else {
-                    isPointerLocked = false;
-                    pointerLockEscTimer = setTimeout(() => {
-                        if (sdk && sdk.gameInstance && sdk.gameInstance.configs && sdk.gameInstance.configs.enableReplenishEsc) {
-                            try {
-                                if (typeof sdk.sendDataToGame === "function") {
-                                    sdk.sendDataToGame(new Uint8Array([0x1b]));
-                                }
-                            } catch {
-                            }
-                        }
-                    }, 200);
-                }
-            });
-
-            const requestPointerLockOnVideo = () => {
-                const video = document.getElementById("WelinkGameVideo");
-                if (video && typeof video.requestPointerLock === "function") {
-                    try {
-                        video.requestPointerLock();
-                    } catch {
-                    }
-                }
-            };
-
             const setupVideoMouseHandlers = () => {
                 const video = document.getElementById("WelinkGameVideo");
                 if (!video || video._kuroMouseHandlersSetup) {
@@ -1213,8 +1184,7 @@ public static class CloudGameBuilder
                 }
                 video._kuroMouseHandlersSetup = true;
 
-                video.addEventListener("mousedown", (e) => {
-                    requestPointerLockOnVideo();
+                video.addEventListener("mousedown", () => {
                     focusSurface();
                 }, true);
 
@@ -1353,6 +1323,17 @@ public static class CloudGameBuilder
                             message: `Welink startGameError: code=${code}${suffix}`,
                             code,
                             detail
+                        });
+                    };
+                }
+
+                if (typeof sdk.onCursorData !== "undefined") {
+                    sdk.onCursorData = (visible, url, xHotspot, yHotspot) => {
+                        post("cursor-data", {
+                            visible: Boolean(visible),
+                            hasImage: Boolean(url),
+                            xHotspot: Number(xHotspot) || 0,
+                            yHotspot: Number(yHotspot) || 0
                         });
                     };
                 }

--- a/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.Active.cs
+++ b/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.Active.cs
@@ -89,10 +89,16 @@ partial class CloudGameingViewModel
 
     public override void Dispose()
     {
-        WebView2.Close();
-        this._cursorTimer.Stop();
-        this._hotkeyTimer.Stop();
+        ShowSystemCursor();
+        ReleaseWebViewCursorSubclass();
+        if (Window is not null)
+        {
+            Window.Activated -= Window_Activated;
+        }
+        WebView2?.Close();
+        this._cursorTimer?.Stop();
         this._cursorTimer = null;
+        this._hotkeyTimer?.Stop();
         this._hotkeyTimer = null;
     }
 }

--- a/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.SystemCursor.cs
+++ b/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.SystemCursor.cs
@@ -11,27 +11,29 @@ partial class CloudGameingViewModel
     private const int CURSOR_SHOWING = 0x00000001;
     private const uint SPI_SETCURSORS = 0x0057;
     private const uint WM_SETCURSOR = 0x0020;
+    private const uint WM_MOUSEMOVE = 0x0200;
+    private const uint HTCLIENT = 1;
     private delegate bool EnumWindowsProc(IntPtr windowHandle, IntPtr lParam);
+    private static readonly UIntPtr WebViewCursorSubclassId = new(0x48415955);
     private static readonly uint[] SystemCursorIds =
     [
         32512, // OCR_NORMAL
-            32513, // OCR_IBEAM
-            32514, // OCR_WAIT
-            32515, // OCR_CROSS
-            32516, // OCR_UP
-            32642, // OCR_SIZENWSE
-            32643, // OCR_SIZENESW
-            32644, // OCR_SIZEWE
-            32645, // OCR_SIZENS
-            32646, // OCR_SIZEALL
-            32648, // OCR_NO
-            32649, // OCR_HAND
-            32650, // OCR_APPSTARTING
-            32651, // OCR_HELP
-            32671, // OCR_PIN
-            32672, // OCR_PERSON
-        ];
-
+        32513, // OCR_IBEAM
+        32514, // OCR_WAIT
+        32515, // OCR_CROSS
+        32516, // OCR_UP
+        32642, // OCR_SIZENWSE
+        32643, // OCR_SIZENESW
+        32644, // OCR_SIZEWE
+        32645, // OCR_SIZENS
+        32646, // OCR_SIZEALL
+        32648, // OCR_NO
+        32649, // OCR_HAND
+        32650, // OCR_APPSTARTING
+        32651, // OCR_HELP
+        32671, // OCR_PIN
+        32672, // OCR_PERSON
+    ];
 
     private delegate IntPtr SUBCLASSPROC(
         IntPtr windowHandle,
@@ -42,52 +44,58 @@ partial class CloudGameingViewModel
         UIntPtr referenceData
     );
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct CURSORINFO
-    {
-        public int cbSize;
-        public int flags;
-        public IntPtr hCursor;
-        public POINT ptScreenPos;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int X;
-        public int Y;
-    }
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetCursor(IntPtr hCursor);
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetCursorInfo(out CURSORINFO pci);
+    private static extern bool GetCursorInfo(out CURSORINFO cursorInfo);
 
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetSystemCursor(IntPtr hcur, uint id);
+    private static extern bool SetSystemCursor(IntPtr cursor, uint cursorId);
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern IntPtr CreateCursor(
-        IntPtr hInst,
+        IntPtr instance,
         int xHotSpot,
         int yHotSpot,
-        int nWidth,
-        int nHeight,
-        byte[] pvANDPlane,
-        byte[] pvXORPlane
+        int width,
+        int height,
+        byte[] andPlane,
+        byte[] xorPlane
     );
 
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool SystemParametersInfo(
-        uint uiAction,
-        uint uiParam,
-        IntPtr pvParam,
-        uint fWinIni
+        uint action,
+        uint parameter,
+        IntPtr data,
+        uint flags
     );
 
     [DllImport("user32.dll")]
-    private static extern IntPtr SetCursor(IntPtr hCursor);
+    private static extern int ShowCursor(bool show);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsChild(IntPtr parentWindow, IntPtr window);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr WindowFromPoint(POINT point);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorPos(out POINT point);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SendMessage(
+        IntPtr window,
+        uint message,
+        IntPtr wParam,
+        IntPtr lParam
+    );
 
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     private static extern int GetClassName(
@@ -130,10 +138,122 @@ partial class CloudGameingViewModel
     );
 
     [DllImport("user32.dll")]
-    private static extern int ShowCursor(bool bShow);
-
-    [DllImport("user32.dll")]
     private static extern short GetAsyncKeyState(int vKey);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CURSORINFO
+    {
+        public int cbSize;
+        public int flags;
+        public IntPtr hCursor;
+        public POINT ptScreenPos;
+    }
+    #endregion
+
+    private bool _cursorHidden;
+    private bool _cloudCursorHiddenRequested;
+    private bool _windowIsActive = true;
+    private bool _systemCursorSchemeOverridden;
+    private bool _webViewCursorSubclassInstalled;
+    private nint _webViewWindowHandle;
+    private DispatcherTimer _cursorTimer;
+    private DispatcherTimer _hotkeyTimer;
+    private bool _f11WasDown;
+    private SUBCLASSPROC _webViewCursorSubclassProc;
+
+    private void HideSystemCursor()
+    {
+        if (!_windowIsActive)
+        {
+            return;
+        }
+
+        if (_cursorHidden && _systemCursorSchemeOverridden)
+        {
+            return;
+        }
+
+        _cursorHidden = true;
+
+        TryInstallWebViewCursorSubclass();
+        OverrideSystemCursorsWithTransparent();
+        EnsureSystemCursorHidden();
+
+        var hitWindow = GetWebViewWindowUnderCursor();
+        if (_webViewCursorSubclassInstalled && hitWindow != IntPtr.Zero)
+        {
+            _ = SetCursor(IntPtr.Zero);
+        }
+
+        if (_cursorTimer is null)
+        {
+            _cursorTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(50)
+            };
+            _cursorTimer.Tick += (_, _) =>
+            {
+                if (_cursorHidden && IsSystemCursorVisible())
+                {
+                    EnsureSystemCursorHidden();
+                }
+            };
+        }
+
+        _cursorTimer.Start();
+    }
+
+    public void ShowSystemCursor()
+    {
+        _cursorHidden = false;
+        _cursorTimer?.Stop();
+        RestoreSystemCursors();
+        while (ShowCursor(true) < 0) { }
+
+        var hitWindow = GetWebViewWindowUnderCursor();
+        if (hitWindow != IntPtr.Zero)
+        {
+            var setCursorLParam = new IntPtr(
+                unchecked((int)((WM_MOUSEMOVE << 16) | HTCLIENT))
+            );
+            _ = SendMessage(hitWindow, WM_SETCURSOR, hitWindow, setCursorLParam);
+        }
+    }
+
+    private void ApplyCloudCursorVisibility(bool visible)
+    {
+        _cloudCursorHiddenRequested = !visible;
+
+        if (_cloudCursorHiddenRequested && _windowIsActive)
+        {
+            HideSystemCursor();
+        }
+        else
+        {
+            ShowSystemCursor();
+        }
+    }
+
+    private void ApplyWindowActivationState(bool isActive)
+    {
+        _windowIsActive = isActive;
+
+        if (_windowIsActive && _cloudCursorHiddenRequested)
+        {
+            HideSystemCursor();
+        }
+        else
+        {
+            ShowSystemCursor();
+        }
+    }
 
     private static bool IsSystemCursorVisible()
     {
@@ -145,70 +265,10 @@ partial class CloudGameingViewModel
         return GetCursorInfo(out cursorInfo)
             && (cursorInfo.flags & CURSOR_SHOWING) == CURSOR_SHOWING;
     }
-    #endregion
-
-    private bool _cursorHidden;
-    private bool _webViewCursorSubclassInstalled;
-    private nint _webViewChildHandle;
-
-    private bool _isClosingRequested;
-    private bool _systemCursorSchemeOverridden;
-    private DispatcherTimer _cursorTimer;
-    private DispatcherTimer _hotkeyTimer;
-    private bool _altQWasDown;
-    private IntPtr _windowHandle;
-    private SUBCLASSPROC _webViewCursorSubclassProc;
-
-    private void HideSystemCursor()
-    {
-        if (_cursorHidden)
-        {
-            return;
-        }
-
-        _cursorHidden = true;
-
-        TryInstallWebViewCursorSubclass();
-        OverrideSystemCursorsWithTransparent();
-        EnsureSystemCursorHidden();
-
-        if (_cursorTimer is null)
-        {
-            _cursorTimer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(100)
-            };
-            _cursorTimer.Tick += (_, _) =>
-            {
-                if (_cursorHidden && !_webViewCursorSubclassInstalled)
-                {
-                    TryInstallWebViewCursorSubclass();
-                }
-
-                if (_cursorHidden && IsSystemCursorVisible())
-                {
-                    EnsureSystemCursorHidden();
-                }
-            };
-        }
-
-        _cursorTimer.Start();
-    }
 
     private static void EnsureSystemCursorHidden()
     {
         while (ShowCursor(false) >= 0) { }
-    }
-
-    private void RestoreSystemCursors()
-    {
-        if (!_systemCursorSchemeOverridden)
-        {
-            return;
-        }
-
-        _ = SystemParametersInfo(SPI_SETCURSORS, 0, IntPtr.Zero, 0);
-        _systemCursorSchemeOverridden = false;
     }
 
     private void OverrideSystemCursorsWithTransparent()
@@ -230,38 +290,22 @@ partial class CloudGameingViewModel
         _systemCursorSchemeOverridden = true;
     }
 
+    private void RestoreSystemCursors()
+    {
+        if (!_systemCursorSchemeOverridden)
+        {
+            return;
+        }
+
+        _ = SystemParametersInfo(SPI_SETCURSORS, 0, IntPtr.Zero, 0);
+        _systemCursorSchemeOverridden = false;
+    }
 
     private static IntPtr CreateTransparentCursorHandle()
     {
         byte[] andMask = [0xFF, 0xFF, 0xFF, 0xFF];
         byte[] xorMask = [0x00, 0x00, 0x00, 0x00];
         return CreateCursor(IntPtr.Zero, 0, 0, 1, 1, andMask, xorMask);
-    }
-
-    public void ShowSystemCursor()
-    {
-        if (!_cursorHidden)
-        {
-            return;
-        }
-
-        _cursorHidden = false;
-        _cursorTimer?.Stop();
-
-        RestoreSystemCursors();
-        while (ShowCursor(true) < 0) { }
-    }
-
-    private void ToggleSystemCursor()
-    {
-        if (_cursorHidden)
-        {
-            ShowSystemCursor();
-        }
-        else
-        {
-            HideSystemCursor();
-        }
     }
 
     private void StartHotkeyTimer()
@@ -275,23 +319,17 @@ partial class CloudGameingViewModel
         {
             Interval = TimeSpan.FromMilliseconds(100)
         };
-        _hotkeyTimer.Tick += async(_, _) =>
+        _hotkeyTimer.Tick += async (_, _) =>
         {
-            var altDown = (GetAsyncKeyState(0x12) & 0x8000) != 0;
-            var qDown = (GetAsyncKeyState(0x51) & 0x8000) != 0;
             var f11Down = (GetAsyncKeyState(0x7A) & 0x8000) != 0;
-            if (altDown && qDown && !_altQWasDown)
+            if (f11Down && !_f11WasDown)
             {
-                _altQWasDown = true;
-                ToggleSystemCursor();
-            }
-            if (f11Down)
-            {
+                _f11WasDown = true;
                 await ToggleFullScreenAsync();
             }
-            else if (!altDown || !qDown)
+            else if (!f11Down)
             {
-                _altQWasDown = false;
+                _f11WasDown = false;
             }
         };
         _hotkeyTimer.Start();
@@ -334,19 +372,47 @@ partial class CloudGameingViewModel
             }
         }
 
-        _webViewChildHandle = FindWebViewChildWindow(WindowHandle);
-        if (_webViewChildHandle == IntPtr.Zero)
+        _webViewWindowHandle = FindWebViewChildWindow(WindowHandle);
+        if (_webViewWindowHandle == IntPtr.Zero)
         {
             return;
         }
 
         _webViewCursorSubclassProc ??= WebViewCursorSubclassProc;
         _webViewCursorSubclassInstalled = SetWindowSubclass(
-            _webViewChildHandle,
+            WindowHandle,
             _webViewCursorSubclassProc,
-            UIntPtr.Zero,
+            WebViewCursorSubclassId,
             UIntPtr.Zero
         );
+
+        if (
+            _webViewCursorSubclassInstalled
+            && _cursorHidden
+            && GetWebViewWindowUnderCursor() != IntPtr.Zero
+        )
+        {
+            _ = SetCursor(IntPtr.Zero);
+        }
+    }
+
+    private void ReleaseWebViewCursorSubclass()
+    {
+        if (
+            _webViewCursorSubclassInstalled
+            && WindowHandle != IntPtr.Zero
+            && _webViewCursorSubclassProc is not null
+        )
+        {
+            _ = RemoveWindowSubclass(
+                WindowHandle,
+                _webViewCursorSubclassProc,
+                WebViewCursorSubclassId
+            );
+        }
+
+        _webViewCursorSubclassInstalled = false;
+        _webViewWindowHandle = IntPtr.Zero;
     }
 
     private IntPtr WebViewCursorSubclassProc(
@@ -358,7 +424,11 @@ partial class CloudGameingViewModel
             UIntPtr referenceData
         )
     {
-        if (_cursorHidden && message == WM_SETCURSOR)
+        if (
+            _cursorHidden
+            && message == WM_SETCURSOR
+            && IsWebViewHitWindow(wParam)
+        )
         {
             SetCursor(IntPtr.Zero);
             return new IntPtr(1);
@@ -381,13 +451,6 @@ partial class CloudGameingViewModel
                     return false;
                 }
 
-                var descendant = FindWebViewChildWindow(childHandle);
-                if (descendant != IntPtr.Zero)
-                {
-                    result = descendant;
-                    return false;
-                }
-
                 return true;
             },
             IntPtr.Zero
@@ -404,6 +467,30 @@ partial class CloudGameingViewModel
 
         return className.StartsWith("Chrome_WidgetWin_", StringComparison.Ordinal)
             || className.Contains("WebView", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IntPtr GetWebViewWindowUnderCursor()
+    {
+        if (
+            _webViewWindowHandle == IntPtr.Zero
+            || !GetCursorPos(out var cursorPosition)
+        )
+        {
+            return IntPtr.Zero;
+        }
+
+        var hitWindow = WindowFromPoint(cursorPosition);
+        return IsWebViewHitWindow(hitWindow) ? hitWindow : IntPtr.Zero;
+    }
+
+    private bool IsWebViewHitWindow(IntPtr hitWindow)
+    {
+        return hitWindow != IntPtr.Zero
+            && _webViewWindowHandle != IntPtr.Zero
+            && (
+                hitWindow == _webViewWindowHandle
+                || IsChild(_webViewWindowHandle, hitWindow)
+            );
     }
 
 

--- a/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.cs
+++ b/src/WutheringWavesTool/ViewModel/GameViewModels/CloudGameingViewModel/CloudGameingViewModel.cs
@@ -66,6 +66,14 @@ public sealed partial class CloudGameingViewModel:ViewModelBase
         this.Window = window;
         this.Option = option;
         this.Window.Closed += Window_Closed;
+        this.Window.Activated += Window_Activated;
+    }
+
+    private void Window_Activated(object sender, WindowActivatedEventArgs args)
+    {
+        ApplyWindowActivationState(
+            args.WindowActivationState != WindowActivationState.Deactivated
+        );
     }
 
     private async void Window_Closed(object sender, WindowEventArgs args)
@@ -318,8 +326,7 @@ public sealed partial class CloudGameingViewModel:ViewModelBase
                     UpdateNetworkDisplay(model);
                     break;
                 case "cursor-data":
-                    break;
-                case "pointer-lock":
+                    ApplyCloudCursorVisibility(model.Visible);
                     break;
                 case "error":
                     ShowSystemCursor();

--- a/src/WutheringWavesTool/WindowModels/CloudGameWindows.xaml.cs
+++ b/src/WutheringWavesTool/WindowModels/CloudGameWindows.xaml.cs
@@ -7,6 +7,9 @@ namespace Haiyu.WindowModels;
 
 public sealed partial class CloudGameWindows : Window
 {
+    private const int InitialWindowWidth = 1920;
+    private const int InitialWindowHeight = 1080;
+
     public CloudGameingViewModel ViewModel { get; private set; }
     public CloudGameSettingViewModel CloudSettingModel { get; }
 
@@ -15,12 +18,33 @@ public sealed partial class CloudGameWindows : Window
         InitializeComponent();
         this.ExtendsContentIntoTitleBar = true;
         this.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+        SetInitialWindowBounds();
         this.ViewModel = Instance.Host.Services.GetRequiredService<CloudGameingViewModel>();
         this.CloudSettingModel = Instance.Host.Services.GetRequiredService<CloudGameSettingViewModel>();
         ViewModel.SetWebView(this._browser, this, option);
         this.AppWindow.Closing += CloudGameWindows_Closing;
         this.grid.RequestedTheme = Instance.Host.Services.GetRequiredService<IThemeService>().CurrentTheme;
         this._browser.RequestedTheme = Instance.Host.Services.GetRequiredService<IThemeService>().CurrentTheme;
+    }
+
+    private void SetInitialWindowBounds()
+    {
+        var displayArea = DisplayArea.GetFromWindowId(
+            this.AppWindow.Id,
+            DisplayAreaFallback.Primary
+        );
+        var workArea = displayArea.WorkArea;
+        var x = workArea.X + Math.Max(0, (workArea.Width - InitialWindowWidth) / 2);
+        var y = workArea.Y + Math.Max(0, (workArea.Height - InitialWindowHeight) / 2);
+
+        this.AppWindow.Resize(
+            new Windows.Graphics.SizeInt32
+            {
+                Width = InitialWindowWidth,
+                Height = InitialWindowHeight,
+            }
+        );
+        this.AppWindow.Move(new Windows.Graphics.PointInt32 { X = x, Y = y });
     }
 
     


### PR DESCRIPTION
## 变更内容

- 根据 Welink `onCursorData` 自动切换系统光标显隐，进入游戏视角时隐藏光标，回到界面交互时自动恢复。
- 移除额外 Pointer Lock 带来的反向拖拽和边缘回中问题，并完善窗口失焦、退出时的光标恢复。
- 将“原生”串流固定为 `1920×1080 @ 25 Mbps`，“流畅”档保持 `1280×720`。
- 让 SDK 初始化及运行时分辨率统一采用已计算的目标分辨率。
- 云游戏窗口默认以 `1920×1080` 物理像素创建，并在当前显示器工作区居中。

## 原因

WebView2 无法直接使用 Welink 下发的自定义光标，原实现只能通过 Alt+Q 手动切换透明系统光标，导致游戏视角和界面鼠标交互需要反复解锁。与此同时，实际测试和官方 WebRTC 统计均显示 Web 串流最高为 1920 宽，继续请求 2K 只会提高 1080P 流的码率，无法增加真实画面细节。

## 影响

- 游戏视角与 UI 交互之间不再需要手动按 Alt+Q。
- 避免鼠标轴反向、拖拽感和触边回中循环。
- 1080P 串流最高约 `3.05 MB/s`，减少无效带宽消耗。
- 默认窗口尺寸与实际串流分辨率匹配。

## 验证

- 嵌入式桥接 JavaScript 已通过 `node --check`。
- `dotnet publish` Release x64 构建成功，无编译错误。
- 已在 Windows/WebView2 云游戏会话中人工验证鼠标自动隐藏、恢复和视角方向。
